### PR TITLE
Add claude-auth command to CLI package

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,14 @@ devs vscode frontend backend
 # Work in a specific container
 devs shell frontend
 
+# Run Claude in a container
+devs claude frontend "Summarize this codebase"
+
+# Set up Claude authentication (once per host)
+devs claude-auth
+# Or with API key
+devs claude-auth --api-key <YOUR_API_KEY>
+
 # Clean up when done
 devs stop frontend backend
 


### PR DESCRIPTION
## Summary
This PR adds a new `claude-auth` command to the CLI package that allows users to authenticate with Claude directly from the host machine, eliminating the need to shell into a container for the initial authentication setup.

## Changes
- Added `claude-auth` command to `packages/cli/devs/cli.py`
- Supports both interactive authentication and API key authentication via `--api-key` flag
- Uses `CLAUDE_CONFIG_DIR` environment variable to save authentication to `~/.devs/claudeconfig`
- Added comprehensive test coverage for the new command
- Updated README with documentation for the new command

## How it works
The command runs `claude auth` on the host machine with `CLAUDE_CONFIG_DIR` pointing to `~/.devs/claudeconfig`. This directory is already bind-mounted into all containers at `/home/node/claudeconfig`, so authentication done on the host is automatically available in all containers.

## Usage
```bash
# Interactive authentication (recommended)
devs claude-auth

# With API key
devs claude-auth --api-key <YOUR_API_KEY>
```

## Testing
- Added unit tests for help text, API key mode, interactive mode, and error handling
- All tests pass successfully

## Requirements
- Claude CLI must be installed on the host machine (`npm install -g @anthropic-ai/claude-cli`)
- The command provides clear error messages if Claude CLI is not found

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)