### PR TITLE
Fix eyes reaction for issue comments

### DIFF
--- a/packages/webhook/devs_webhook/github/client.py
+++ b/packages/webhook/devs_webhook/github/client.py
@@ -203,7 +203,7 @@ class GitHubClient:
         """
         try:
             repository = self.github.get_repo(repo)
-            comment = repository.get_issue_comment(comment_id)
+            comment = repository.get_comment(comment_id)
             comment.create_reaction(reaction)
             
             logger.info("Reaction added to comment",


### PR DESCRIPTION
## Summary
- Fixed AttributeError when adding eyes reaction to issue comments
- Changed `repository.get_issue_comment()` to `repository.get_comment()` to match PyGithub API

## Problem
The webhook was failing to add eyes reactions to issue comments with the error:
```
'Repository' object has no attribute 'get_issue_comment'
```

## Solution
The PyGithub Repository class uses `get_comment(id)` method, not `get_issue_comment(comment_id)`. This PR corrects the method name to fix the AttributeError.

## Test plan
- [ ] Deploy the updated webhook handler
- [ ] Create an issue comment that mentions the bot
- [ ] Verify the eyes reaction appears on the comment

Closes #17

🤖 Generated with [Claude Code](https://claude.ai/code)