### PR TITLE
Configure Claude settings to disable co-authored-by in commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -156,4 +156,7 @@ loclx-config.yaml
 .devmode.zsh
 nohup.out
 
+# Claude settings
 .claude/
+!.claude/settings.json
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
This PR configures Claude Code settings to prevent it from adding co-authored-by messages and 'Generated with Claude Code' text in commits and PRs.

## Changes
- Updated  to track  but ignore 
- Added  with 

## Note
As mentioned by @danlester, this only affects the devs project itself. Container projects will be handled separately.

Closes #19