### PR TITLE
Fix webhook authentication error due to name conflict

### DIFF
--- a/packages/webhook/devs_webhook/app.py
+++ b/packages/webhook/devs_webhook/app.py
@@ -190,7 +190,7 @@ async def handle_webhook(request: Request, background_tasks: BackgroundTasks):
 
 
 @app.get("/status")
-async def status(username: str = Depends(verify_admin_credentials)):
+async def get_status(username: str = Depends(verify_admin_credentials)):
     """Get current webhook handler status.
     
     Requires admin authentication.


### PR DESCRIPTION
## Summary
- Fixed AttributeError in webhook authentication when wrong credentials are provided
- Renamed the `status` function to `get_status` to avoid shadowing the imported `status` module from FastAPI

## Problem
The webhook server was crashing with the error:
```
AttributeError: 'function' object has no attribute 'HTTP_401_UNAUTHORIZED'
```

This occurred at line 94 in `verify_admin_credentials` when trying to access `status.HTTP_401_UNAUTHORIZED`.

## Root Cause
The function `status` (defined at line 193) was shadowing the imported `status` module from FastAPI. When Python tried to access `status.HTTP_401_UNAUTHORIZED` in the `verify_admin_credentials` function, it was referencing the function instead of the module.

## Solution
Renamed the endpoint function from `status` to `get_status` to eliminate the naming conflict. The endpoint URL `/status` remains unchanged - only the internal function name was modified.

## Test plan
- [x] Code review shows the fix addresses the issue
- [ ] Manual testing with incorrect credentials should return 401 without crashing
- [ ] All existing authentication tests should pass
- [ ] The `/status` endpoint should continue to work as expected

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)