### PR TITLE
Fix double authentication prompt in FastAPI docs

### DIFF
--- a/packages/webhook/devs_webhook/app.py
+++ b/packages/webhook/devs_webhook/app.py
@@ -92,8 +92,7 @@ def verify_admin_credentials(
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
-            headers={"WWW-Authenticate": "Basic"},
+            detail="Invalid authentication credentials"
         )
     
     return credentials.username
@@ -233,7 +232,8 @@ async def list_containers(username: str = Depends(verify_admin_credentials)):
 @app.post("/testevent")
 async def test_event(
     request: TestEventRequest,
-    config: WebhookConfig = Depends(require_dev_mode)
+    config: WebhookConfig = Depends(require_dev_mode),
+    username: str = Depends(verify_admin_credentials)
 ):
     """Test endpoint to simulate GitHub webhook events with custom prompts.
     


### PR DESCRIPTION
## Summary
Fixes the double authentication prompt issue where the browser was showing its native HTTP Basic auth dialog in addition to FastAPI's Swagger UI authentication.

## Problem
When accessing the FastAPI `/docs` page and using protected endpoints, users were experiencing:
1. First entering credentials in the FastAPI Swagger UI "Authorize" button
2. Then being prompted again by the browser's native auth dialog

This was happening because the `WWW-Authenticate: Basic` header in 401 responses triggers the browser's built-in authentication mechanism.

## Solution
- **Removed the `WWW-Authenticate` header** from the 401 response in `verify_admin_credentials()`
  - This prevents the browser from showing its native auth dialog
  - FastAPI's Swagger UI handles authentication internally without needing this header
  
- **Added admin authentication to `/testevent` endpoint** for consistency
  - This endpoint was only checking for dev_mode but not requiring admin auth
  - Now it properly requires both dev_mode AND admin credentials

## Testing
The authentication now works as intended:
- Users only need to enter credentials once in the FastAPI docs interface
- The browser no longer prompts with its own auth dialog
- All secured endpoints properly require authentication

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)