### PR TITLE
Fix JSON parsing error in webhook handler

### DIFF
--- a/packages/common/devs_common/core/workspace.py
+++ b/packages/common/devs_common/core/workspace.py
@@ -1,5 +1,7 @@
 """Workspace management and isolation."""
 
+import os
+import sys
 import shutil
 from pathlib import Path
 from typing import List, Optional, Set
@@ -18,7 +20,12 @@ from ..utils.file_utils import (
 from ..utils.git_utils import get_tracked_files, is_git_repository
 from .project import Project
 
-console = Console()
+# Initialize Rich console
+# When running in webhook mode, output to stderr to avoid mixing with JSON output
+if os.environ.get('DEVS_WEBHOOK_MODE') == '1':
+    console = Console(stderr=True)
+else:
+    console = Console()
 
 
 class WorkspaceManager:

--- a/packages/common/devs_common/utils/devcontainer.py
+++ b/packages/common/devs_common/utils/devcontainer.py
@@ -69,8 +69,14 @@ class DevContainerCLI:
                 pass
         
         if not has_env_token and not has_file_token:
+            import os
+            import sys
             from rich.console import Console
-            console = Console()
+            # When running in webhook mode, output to stderr to avoid mixing with JSON output
+            if os.environ.get('DEVS_WEBHOOK_MODE') == '1':
+                console = Console(stderr=True)
+            else:
+                console = Console()
             console.print()
             console.print("⚠️  [bold yellow]GitHub Token Not Configured[/bold yellow]")
             console.print("   GitHub operations (private repos, API access) may fail.")
@@ -170,8 +176,14 @@ class DevContainerCLI:
                 env['DEVS_DEBUG'] = 'true'
             
             if debug:
+                import os
+                import sys
                 from rich.console import Console
-                console = Console()
+                # When running in webhook mode, output to stderr to avoid mixing with JSON output
+                if os.environ.get('DEVS_WEBHOOK_MODE') == '1':
+                    console = Console(stderr=True)
+                else:
+                    console = Console()
                 console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
                 console.print(f"[dim]Environment variables: DEVCONTAINER_NAME={env.get('DEVCONTAINER_NAME')}, GIT_REMOTE_URL={env.get('GIT_REMOTE_URL')}, GH_TOKEN={'***' if env.get('GH_TOKEN') else 'not set'}, DEVS_DEBUG={env.get('DEVS_DEBUG', 'not set')}[/dim]")
             
@@ -196,8 +208,14 @@ class DevContainerCLI:
                 )
             
             if debug and result.returncode == 0:
+                import os
+                import sys
                 from rich.console import Console
-                console = Console()
+                # When running in webhook mode, output to stderr to avoid mixing with JSON output
+                if os.environ.get('DEVS_WEBHOOK_MODE') == '1':
+                    console = Console(stderr=True)
+                else:
+                    console = Console()
                 console.print("[dim]DevContainer up completed successfully[/dim]")
             
             if result.returncode != 0:

--- a/packages/webhook/devs_webhook/cli/worker.py
+++ b/packages/webhook/devs_webhook/cli/worker.py
@@ -43,7 +43,17 @@ def worker(task_id: str, dev_name: str, repo_name: str, repo_path: str, timeout:
         "devs_options": {...devs options object...} (optional)
     }
     """
-    # Configure structured logging for subprocess
+    # Set environment variable to redirect console output to stderr
+    os.environ['DEVS_WEBHOOK_MODE'] = '1'
+    
+    # Configure structured logging for subprocess to output to stderr
+    import logging
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format='%(message)s'
+    )
+    
     structlog.configure(
         processors=[
             structlog.stdlib.filter_by_level,


### PR DESCRIPTION
## Summary

This PR fixes the JSON parsing error that was occurring in the webhook handler when processing tasks.

## Problem

The webhook handler was failing with the error:
```
"Expecting value: line 1 column 4 (char 3)"
```

This happened because:
1. The worker subprocess executes devs CLI commands (workspace creation, container management)
2. These commands print progress messages to stdout using Rich console
3. The worker then outputs JSON results to stdout
4. The two outputs get mixed together, corrupting the JSON

Example of the mixed output causing the issue:
```
   🗑️  Resetting existing workspace for kevin...
   📂 Creating isolated workspace copy for kevin...
🤖 Running Claude in: kevin (container: dev-workstuffai-workstuffapp-kevin)
{"success": true, "output": "I've successfully addressed Dan's feedback
```

## Solution

The fix separates CLI output from JSON output by:

1. **Setting `DEVS_WEBHOOK_MODE=1` environment variable** in the worker subprocess
2. **Redirecting console output to stderr** in webhook mode across all devs modules:
   - `devs_common/core/workspace.py`
   - `devs_common/core/container.py`
   - `devs_common/utils/devcontainer.py`
3. **Configuring structured logging to use stderr** in the worker

Now:
- Progress messages and logs go to **stderr**
- JSON results go to **stdout**
- No mixing of outputs
- JSON parsing succeeds

## Testing

The fix ensures that when running in webhook mode, all Rich console output is redirected to stderr, preventing it from interfering with the JSON output on stdout.

Closes #29

🤖 Generated with [Claude Code](https://claude.ai/code)