### PR TITLE
Fix: DRY up repetitive Dockerfile commands

### DIFF
--- a/packages/common/devs_common/templates/Dockerfile
+++ b/packages/common/devs_common/templates/Dockerfile
@@ -118,14 +118,12 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 # Install Claude CLI
 RUN npm install -g @anthropic-ai/claude-code
 
-# Set up environment variables for Claude
+# Set up environment variables and aliases for Claude
 USER root
-RUN echo "export CLAUDE_CONFIG_DIR=\"/home/node/claudeconfig\"" >> /home/node/.zshrc && \
-  echo "export CLAUDE_CONFIG_DIR=\"/home/node/claudeconfig\"" >> /home/node/.bashrc
-
-# Alias for claude
-RUN echo "alias claude=\"/usr/local/share/npm-global/bin/claude --dangerously-skip-permissions\"" >> /home/node/.zshrc && \
-  echo "alias claude=\"/usr/local/share/npm-global/bin/claude --dangerously-skip-permissions\"" >> /home/node/.bashrc
+RUN for shell_rc in /home/node/.zshrc /home/node/.bashrc; do \
+    echo "export CLAUDE_CONFIG_DIR=\"/home/node/claudeconfig\"" >> "$shell_rc" && \
+    echo "alias claude=\"/usr/local/share/npm-global/bin/claude --dangerously-skip-permissions\"" >> "$shell_rc"; \
+  done
 
 
 # Copy and set up scripts


### PR DESCRIPTION
## Summary
- Refactored repetitive Dockerfile commands that were duplicating the same content to both .zshrc and .bashrc files
- Consolidated into a single loop-based approach for better maintainability

## Changes
- Combined 2 separate RUN commands into 1 using a shell loop
- Iterates over both `/home/node/.zshrc` and `/home/node/.bashrc` files
- Appends both the CLAUDE_CONFIG_DIR export and the claude alias in the same loop
- Maintains the ability to use variables in the strings as requested

## Before
```dockerfile
RUN echo "export CLAUDE_CONFIG_DIR=\"/home/node/claudeconfig\"" >> /home/node/.zshrc && \
  echo "export CLAUDE_CONFIG_DIR=\"/home/node/claudeconfig\"" >> /home/node/.bashrc

RUN echo "alias claude=\"/usr/local/share/npm-global/bin/claude --dangerously-skip-permissions\"" >> /home/node/.zshrc && \
  echo "alias claude=\"/usr/local/share/npm-global/bin/claude --dangerously-skip-permissions\"" >> /home/node/.bashrc
```

## After
```dockerfile
RUN for shell_rc in /home/node/.zshrc /home/node/.bashrc; do \
    echo "export CLAUDE_CONFIG_DIR=\"/home/node/claudeconfig\"" >> "$shell_rc" && \
    echo "alias claude=\"/usr/local/share/npm-global/bin/claude --dangerously-skip-permissions\"" >> "$shell_rc"; \
  done
```

Closes #36