### PR TITLE
Fix: Skip setup-workspace.sh script when in Live mode

### DIFF
--- a/packages/common/devs_common/templates/scripts/setup-workspace.sh
+++ b/packages/common/devs_common/templates/scripts/setup-workspace.sh
@@ -9,6 +9,13 @@ if [ "${DEVS_DEBUG:-}" = "true" ]; then
     set -x  # Enable command tracing
 fi
 
+# Check if we're in live mode - if so, skip workspace setup
+if [ "${DEVS_LIVE_MODE:-}" = "true" ]; then
+    echo "📁 Live mode detected - skipping workspace setup (using host directory directly)"
+    echo "ℹ️  Your host Python environment will be preserved"
+    exit 0
+fi
+
 
 # Function to setup Python virtual environment in a directory
 setup_python_env() {

--- a/packages/common/devs_common/utils/devcontainer.py
+++ b/packages/common/devs_common/utils/devcontainer.py
@@ -18,7 +18,8 @@ def prepare_devcontainer_environment(
     project_name: str,
     workspace_folder: Path,
     git_remote_url: str = "",
-    debug: bool = False
+    debug: bool = False,
+    live: bool = False
 ) -> dict:
     """Prepare environment variables for devcontainer operations.
     
@@ -28,6 +29,7 @@ def prepare_devcontainer_environment(
         workspace_folder: Path to workspace folder
         git_remote_url: Git remote URL (optional)
         debug: Whether debug mode is enabled
+        live: Whether to use live mode (mount current directory)
         
     Returns:
         Dictionary of environment variables
@@ -60,6 +62,10 @@ def prepare_devcontainer_environment(
     # Pass debug mode to container scripts
     if debug:
         env['DEVS_DEBUG'] = 'true'
+    
+    # Pass live mode to container scripts
+    if live:
+        env['DEVS_LIVE_MODE'] = 'true'
     
     # Pass through GH_TOKEN if available (for GitHub authentication)
     if 'GH_TOKEN' in os.environ:
@@ -206,7 +212,8 @@ class DevContainerCLI:
                 project_name=project_name,
                 workspace_folder=workspace_folder,
                 git_remote_url=git_remote_url,
-                debug=debug
+                debug=debug,
+                live=live
             )
             
             # Check if GH_TOKEN is configured and warn if missing


### PR DESCRIPTION
## Summary
- Prevents `setup-workspace.sh` from running when containers are started in Live mode (`--live` flag)
- Preserves host Python environment when using Live mode

## Problem
When the user starts a container in live mode like `devs start dan --live`, the host directory is mounted directly instead of creating a workspace copy. However, `setup-workspace.sh` was still running and potentially modifying the host's Python environment (creating venv, installing packages, etc.), which is undesirable.

## Solution
1. Pass `DEVS_LIVE_MODE=true` environment variable to the container when `--live` flag is used
2. Check for `DEVS_LIVE_MODE` at the beginning of `setup-workspace.sh` and exit early if set
3. Display informative messages to the user about Live mode behavior

## Changes
- Modified `prepare_devcontainer_environment()` in `devcontainer.py` to accept and pass `live` parameter
- Added `DEVS_LIVE_MODE` environment variable when `live=True`  
- Added early exit check in `setup-workspace.sh` when `DEVS_LIVE_MODE=true`

## Testing
- All existing live mode tests pass
- Manually verified that:
  - Normal mode: `setup-workspace.sh` runs as expected
  - Live mode: `setup-workspace.sh` exits early with informative message
  - Environment variable is correctly passed to container

Closes #39