### PR TITLE
Add authorized trigger users access control to webhook handler

### DIFF
--- a/packages/webhook/devs_webhook/core/webhook_handler.py
+++ b/packages/webhook/devs_webhook/core/webhook_handler.py
@@ -108,6 +108,16 @@ class WebhookHandler:
                            delivery_id=delivery_id)
                 return
             
+            # Check if the user who triggered the event is authorized
+            trigger_user = event.sender.login
+            if not self.config.is_user_authorized_to_trigger(trigger_user):
+                logger.warning("User not authorized to trigger webhook processing",
+                              user=trigger_user,
+                              repo=event.repository.full_name,
+                              delivery_id=delivery_id,
+                              event_type=type(event).__name__)
+                return
+            
             # Check if repository is allowed
             repo_owner = event.repository.owner.login
             if not self.config.is_repository_allowed(event.repository.full_name, repo_owner):
@@ -195,6 +205,7 @@ class WebhookHandler:
             "container_pool_size": len(self.config.get_container_pool_list()),
             "containers": container_status,
             "mentioned_user": self.config.github_mentioned_user,
+            "authorized_trigger_users": self.config.get_authorized_trigger_users_list(),
             "deduplication_cache": get_cache_stats(),
         }
     

--- a/packages/webhook/tests/test_authorized_users.py
+++ b/packages/webhook/tests/test_authorized_users.py
@@ -1,0 +1,228 @@
+"""Test authorized trigger users functionality."""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from devs_webhook.config import WebhookConfig
+from devs_webhook.core.webhook_handler import WebhookHandler
+from devs_webhook.github.models import IssueEvent, GitHubRepository, GitHubUser, GitHubIssue
+import json
+
+
+class TestAuthorizedUsers:
+    """Test cases for authorized trigger users feature."""
+    
+    def test_config_parses_authorized_users(self):
+        """Test that config correctly parses authorized trigger users."""
+        with patch.dict('os.environ', {
+            'AUTHORIZED_TRIGGER_USERS': 'alice,bob,charlie'
+        }):
+            config = WebhookConfig()
+            users = config.get_authorized_trigger_users_list()
+            assert users == ['alice', 'bob', 'charlie']
+    
+    def test_config_handles_empty_authorized_users(self):
+        """Test that empty authorized users list allows all."""
+        with patch.dict('os.environ', {
+            'AUTHORIZED_TRIGGER_USERS': ''
+        }):
+            config = WebhookConfig()
+            users = config.get_authorized_trigger_users_list()
+            assert users == []
+            # Should allow any user when list is empty
+            assert config.is_user_authorized_to_trigger('anyone') == True
+    
+    def test_config_handles_whitespace_in_users(self):
+        """Test that whitespace is properly handled in user list."""
+        with patch.dict('os.environ', {
+            'AUTHORIZED_TRIGGER_USERS': ' alice , bob , charlie '
+        }):
+            config = WebhookConfig()
+            users = config.get_authorized_trigger_users_list()
+            assert users == ['alice', 'bob', 'charlie']
+    
+    def test_is_user_authorized_with_configured_users(self):
+        """Test authorization check with configured users."""
+        with patch.dict('os.environ', {
+            'AUTHORIZED_TRIGGER_USERS': 'alice,bob'
+        }):
+            config = WebhookConfig()
+            
+            # Authorized users
+            assert config.is_user_authorized_to_trigger('alice') == True
+            assert config.is_user_authorized_to_trigger('Bob') == True  # Case insensitive
+            assert config.is_user_authorized_to_trigger('ALICE') == True
+            
+            # Unauthorized users
+            assert config.is_user_authorized_to_trigger('charlie') == False
+            assert config.is_user_authorized_to_trigger('unknown') == False
+    
+    def test_is_user_authorized_empty_allows_all(self):
+        """Test that empty authorized list allows all users."""
+        with patch.dict('os.environ', {
+            'AUTHORIZED_TRIGGER_USERS': ''
+        }):
+            config = WebhookConfig()
+            
+            # All users should be allowed
+            assert config.is_user_authorized_to_trigger('anyone') == True
+            assert config.is_user_authorized_to_trigger('random') == True
+            assert config.is_user_authorized_to_trigger('user123') == True
+    
+    @pytest.mark.asyncio
+    async def test_webhook_handler_blocks_unauthorized_user(self):
+        """Test that webhook handler blocks unauthorized users."""
+        # Clear the config cache to ensure we get fresh config
+        from devs_webhook.config import get_config
+        get_config.cache_clear()
+        
+        with patch.dict('os.environ', {
+            'GITHUB_WEBHOOK_SECRET': 'test-secret',
+            'GITHUB_TOKEN': 'test-token',
+            'GITHUB_MENTIONED_USER': 'botuser',
+            'AUTHORIZED_TRIGGER_USERS': 'alice,bob',
+            'ALLOWED_ORGS': 'testorg'
+        }):
+            handler = WebhookHandler()
+            
+            # Create a mock event from unauthorized user
+            headers = {'x-github-event': 'issues'}
+            payload = json.dumps({
+                'action': 'opened',
+                'repository': {
+                    'id': 1,
+                    'name': 'testrepo',
+                    'full_name': 'testorg/testrepo',
+                    'owner': {
+                        'login': 'testorg',
+                        'id': 1,
+                        'avatar_url': 'http://example.com',
+                        'html_url': 'http://example.com'
+                    },
+                    'html_url': 'http://example.com',
+                    'clone_url': 'http://example.com',
+                    'ssh_url': 'http://example.com',
+                    'default_branch': 'main'
+                },
+                'sender': {
+                    'login': 'unauthorized_user',  # Not in authorized list
+                    'id': 999,
+                    'avatar_url': 'http://example.com',
+                    'html_url': 'http://example.com'
+                },
+                'issue': {
+                    'id': 1,
+                    'number': 1,
+                    'title': 'Test issue',
+                    'body': '@botuser please help',
+                    'state': 'open',
+                    'user': {
+                        'login': 'unauthorized_user',
+                        'id': 999,
+                        'avatar_url': 'http://example.com',
+                        'html_url': 'http://example.com'
+                    },
+                    'html_url': 'http://example.com',
+                    'created_at': '2024-01-01T00:00:00Z',
+                    'updated_at': '2024-01-01T00:00:00Z'
+                }
+            }).encode()
+            
+            # Mock the container pool to track if task was queued
+            handler.container_pool.queue_task = MagicMock(return_value=True)
+            
+            # Process the webhook
+            await handler.process_webhook(headers, payload, 'test-delivery-id')
+            
+            # Task should NOT have been queued due to unauthorized user
+            handler.container_pool.queue_task.assert_not_called()
+    
+    @pytest.mark.asyncio
+    async def test_webhook_handler_allows_authorized_user(self):
+        """Test that webhook handler allows authorized users."""
+        # Clear the config cache to ensure we get fresh config
+        from devs_webhook.config import get_config
+        get_config.cache_clear()
+        
+        with patch.dict('os.environ', {
+            'GITHUB_WEBHOOK_SECRET': 'test-secret',
+            'GITHUB_TOKEN': 'test-token',
+            'GITHUB_MENTIONED_USER': 'botuser',
+            'AUTHORIZED_TRIGGER_USERS': 'alice,bob',
+            'ALLOWED_ORGS': 'testorg'
+        }):
+            handler = WebhookHandler()
+            
+            # Create a mock event from authorized user
+            headers = {'x-github-event': 'issues'}
+            payload = json.dumps({
+                'action': 'opened',
+                'repository': {
+                    'id': 1,
+                    'name': 'testrepo',
+                    'full_name': 'testorg/testrepo',
+                    'owner': {
+                        'login': 'testorg',
+                        'id': 1,
+                        'avatar_url': 'http://example.com',
+                        'html_url': 'http://example.com'
+                    },
+                    'html_url': 'http://example.com',
+                    'clone_url': 'http://example.com',
+                    'ssh_url': 'http://example.com',
+                    'default_branch': 'main'
+                },
+                'sender': {
+                    'login': 'alice',  # In authorized list
+                    'id': 123,
+                    'avatar_url': 'http://example.com',
+                    'html_url': 'http://example.com'
+                },
+                'issue': {
+                    'id': 1,
+                    'number': 1,
+                    'title': 'Test issue',
+                    'body': '@botuser please help',
+                    'state': 'open',
+                    'user': {
+                        'login': 'alice',
+                        'id': 123,
+                        'avatar_url': 'http://example.com',
+                        'html_url': 'http://example.com'
+                    },
+                    'html_url': 'http://example.com',
+                    'created_at': '2024-01-01T00:00:00Z',
+                    'updated_at': '2024-01-01T00:00:00Z'
+                }
+            }).encode()
+            
+            # Mock the container pool to track if task was queued
+            handler.container_pool.queue_task = MagicMock(return_value=True)
+            
+            # Process the webhook
+            await handler.process_webhook(headers, payload, 'test-delivery-id')
+            
+            # Task SHOULD have been queued for authorized user
+            handler.container_pool.queue_task.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_status_includes_authorized_users(self):
+        """Test that status endpoint includes authorized trigger users."""
+        # Clear the config cache to ensure we get fresh config
+        from devs_webhook.config import get_config
+        get_config.cache_clear()
+        
+        with patch.dict('os.environ', {
+            'GITHUB_WEBHOOK_SECRET': 'test-secret',
+            'GITHUB_TOKEN': 'test-token',
+            'GITHUB_MENTIONED_USER': 'botuser',
+            'AUTHORIZED_TRIGGER_USERS': 'alice,bob,charlie'
+        }):
+            handler = WebhookHandler()
+            
+            # Mock container pool status with an async mock
+            handler.container_pool.get_status = AsyncMock(return_value={})
+            
+            status = await handler.get_status()
+            
+            assert 'authorized_trigger_users' in status
+            assert status['authorized_trigger_users'] == ['alice', 'bob', 'charlie']


### PR DESCRIPTION
## Summary

This PR implements access control for the webhook handler to restrict which GitHub users can trigger webhook processing. This addresses issue #45 and is particularly important for public repositories to prevent unauthorized users from triggering actions.

## Changes

- ✅ Added `AUTHORIZED_TRIGGER_USERS` environment variable to configuration
- ✅ Implemented authorization check in webhook handler before processing events
- ✅ Updated status endpoint to include list of authorized trigger users
- ✅ Added comprehensive test coverage for the new functionality
- ✅ Updated documentation to explain the access control layers

## How it Works

The webhook handler now checks if the user who triggered the GitHub event is in the list of authorized users:

1. If `AUTHORIZED_TRIGGER_USERS` is set, only users in this comma-separated list can trigger processing
2. If `AUTHORIZED_TRIGGER_USERS` is empty or not set, all users are allowed (backward compatibility)
3. This check happens before repository allowlist and @mention checks

## Configuration Example

```bash
export AUTHORIZED_TRIGGER_USERS="danlester,teamlead,devbot"
```

## Testing

Added comprehensive test suite (`test_authorized_users.py`) that verifies:
- Configuration parsing of authorized users
- Authorization checks with configured users
- Backward compatibility when no users are configured
- Webhook handler correctly blocks unauthorized users
- Webhook handler allows authorized users
- Status endpoint includes authorized users list

All tests pass successfully.

## Security Layers

The webhook handler now has three layers of access control:
1. **Authorized Trigger Users**: Who can trigger events
2. **Repository Allowlist**: Which repos can use the webhook
3. **@mention Detection**: Final check for the bot user mention

Closes #45