### PR TITLE
Add DEVS.yml options for direct commits and prompt customization

### DIFF
--- a/packages/webhook/README.md
+++ b/packages/webhook/README.md
@@ -199,6 +199,11 @@ prompt_extra: |          # Additional instructions for Claude
   - Always use tabs for indentation
   - Keep functions under 50 lines
   - Add JSDoc comments to all public functions
+direct_commit: true      # Commit directly to default branch instead of creating PRs
+prompt_override: |       # Complete replacement for the default prompt (optional)
+  Custom prompt template here...
+  Available variables: {event_type}, {event_type_full}, {task_description},
+  {repo_name}, {workspace_path}, {github_username}
 ```
 
 Available options:
@@ -211,6 +216,19 @@ Available options:
   - Use for project-specific guidelines, coding standards, or constraints
   - Can be multi-line using YAML's `|` syntax
   - Default: empty string
+
+- **`direct_commit`**: Whether to commit directly to the default branch
+  - When `true`, Claude will commit directly to the default branch instead of creating PRs
+  - When `false`, Claude will create feature branches and pull requests (default behavior)
+  - Only creates PRs if there would be merge conflicts
+  - Default: `false`
+
+- **`prompt_override`**: Complete replacement for the default prompt (advanced)
+  - Allows full customization of Claude's instructions
+  - Use Python string formatting with available variables
+  - Variables: `{event_type}`, `{event_type_full}`, `{task_description}`, `{repo_name}`, `{workspace_path}`, `{github_username}`
+  - Takes precedence over all other prompt settings
+  - Default: not set (uses standard prompt)
 
 The webhook handler automatically detects and uses these settings when processing tasks for the repository.
 

--- a/packages/webhook/devs_webhook/core/container_pool.py
+++ b/packages/webhook/devs_webhook/core/container_pool.py
@@ -493,11 +493,17 @@ class ContainerPool:
                             devs_options.default_branch = data['default_branch']
                         if 'prompt_extra' in data:
                             devs_options.prompt_extra = data['prompt_extra']
+                        if 'prompt_override' in data:
+                            devs_options.prompt_override = data['prompt_override']
+                        if 'direct_commit' in data:
+                            devs_options.direct_commit = data['direct_commit']
                         
                         logger.info("Loaded DEVS.yml configuration",
                                    repo=repo_name,
                                    default_branch=devs_options.default_branch,
-                                   has_prompt_extra=bool(devs_options.prompt_extra))
+                                   has_prompt_extra=bool(devs_options.prompt_extra),
+                                   has_prompt_override=bool(devs_options.prompt_override),
+                                   direct_commit=devs_options.direct_commit)
             except Exception as e:
                 logger.warning("Failed to parse DEVS.yml",
                               repo=repo_name,

--- a/packages/webhook/devs_webhook/github/models.py
+++ b/packages/webhook/devs_webhook/github/models.py
@@ -290,6 +290,8 @@ class DevsOptions(BaseModel):
     """DEVS.yml configuration options."""
     default_branch: str = "main"
     prompt_extra: str = ""
+    prompt_override: Optional[str] = None
+    direct_commit: bool = False
 
 
 # Discriminated union for automatic event type detection


### PR DESCRIPTION
## Summary

This PR adds two new configuration options to DEVS.yml that allow repositories to customize how the webhook handler processes issues and creates changes:

1. **`direct_commit`**: When set to `true`, Claude will commit directly to the default branch instead of creating pull requests (unless there would be merge conflicts).

2. **`prompt_override`**: Allows complete customization of the prompt sent to Claude, with variable substitution support.

## Motivation

As requested in ideonate/gitpocket#22, some projects need a development workflow where:
- Changes are committed directly to a dev branch without creating PRs
- The dev branch is the default branch
- PRs are only created when there would be merge conflicts
- Custom prompts can be defined per repository

## Changes

- Added new fields to `DevsOptions` model (`direct_commit` and `prompt_override`)
- Updated `container_pool.py` to read new DEVS.yml fields
- Modified `claude_dispatcher.py` to support three prompt modes:
  - Standard PR-based workflow (default)
  - Direct commit workflow (when `direct_commit=true`)
  - Custom prompt (when `prompt_override` is set)
- Updated webhook README with documentation for new options

## Example Usage

In a repository's `DEVS.yml`:

```yaml
# For direct commits to dev branch
default_branch: dev
direct_commit: true

# Or for complete prompt customization
prompt_override: |
  You are working on {repo_name}.
  Task: {task_description}
  Always commit directly to the main branch.
```

## Backward Compatibility

These changes are fully backward compatible:
- Existing repositories without DEVS.yml continue to work as before
- Existing DEVS.yml files continue to work without changes
- The new options are opt-in and have sensible defaults

## Related

This addresses the requirements from ideonate/gitpocket#22 for flexible development workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)