### PR TITLE
feat(webhook): Add instruction to not auto-close issues

### DIFF
--- a/packages/webhook/devs_webhook/core/claude_dispatcher.py
+++ b/packages/webhook/devs_webhook/core/claude_dispatcher.py
@@ -182,6 +182,8 @@ You should ensure you're on the latest commits in the repo's default branch ({de
 Commit your changes directly to the {devs_options.default_branch if devs_options else 'main'} branch unless there would be conflicts.
 Only create a pull request if there would be merge conflicts when committing to {devs_options.default_branch if devs_options else 'main'}.
 
+IMPORTANT: Do not close the issue unless the user explicitly instructs you to do so. Even if you implement a solution, leave the issue open for the user to review and close when they're satisfied.
+
 If you need to ask for clarification, or if only asked for your thoughts, please respond with a comment on the {event_type}.
 
 You should always comment back in any case to say what you've done (unless you are sure it wasn't intended for you). The `gh` CLI is available for GitHub operations, and you can use `git` too.
@@ -213,6 +215,8 @@ You have been mentioned in a {event_type_full} and need to take action.
 You should ensure you're on the latest commits in the repo's default branch. 
 Generally work on feature branches for changes. 
 Submit any changes as a pull request when done{pr_closing_instruction}.
+
+IMPORTANT: Do not close the issue unless the user explicitly instructs you to do so. Even if you implement a solution, leave the issue open for the user to review and close when they're satisfied.
 
 If you need to ask for clarification, or if only asked for your thoughts, please respond with a comment on the {event_type}.
 


### PR DESCRIPTION
## Summary
- Added explicit instruction to Claude's prompt to not automatically close GitHub issues
- Instruction added to both standard and direct-commit prompt variants
- Users must now explicitly request issue closure for Claude to close them

## Changes
Modified the Claude dispatcher prompt generation in `packages/webhook/devs_webhook/core/claude_dispatcher.py` to include:
- "IMPORTANT: Do not close the issue unless the user explicitly instructs you to do so. Even if you implement a solution, leave the issue open for the user to review and close when they're satisfied."

This change ensures that issues remain open after Claude implements a solution, giving users time to review the work before deciding whether to close the issue.

## Test Plan
- [ ] Deploy to test webhook instance
- [ ] Create test issue and mention Claude  
- [ ] Verify Claude implements solution but does not close the issue
- [ ] Verify issue can still be closed when explicitly requested

Closes #51