### PR TITLE
Move claude-auth functionality into claude --auth

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,9 +40,9 @@ devs start frontend --env DEBUG=true --env API_URL=http://localhost:3000
 devs claude frontend "Fix the tests" --env NODE_ENV=test
 
 # Set up Claude authentication (once per host)
-devs claude-auth
+devs claude --auth
 # Or with API key
-devs claude-auth --api-key <YOUR_API_KEY>
+devs claude --auth --api-key <YOUR_API_KEY>
 
 # Clean up when done
 devs stop frontend backend

--- a/packages/cli/devs/cli.py
+++ b/packages/cli/devs/cli.py
@@ -328,67 +328,80 @@ def shell(dev_name: str, live: bool, env: tuple, debug: bool) -> None:
 
 
 @cli.command()
-@click.argument('dev_name')
-@click.argument('prompt')
+@click.argument('dev_name', required=False)
+@click.argument('prompt', required=False)
+@click.option('--auth', is_flag=True, help='Set up Claude authentication for devcontainers')
+@click.option('--api-key', help='Claude API key to authenticate with (use with --auth)')
 @click.option('--reset-workspace', is_flag=True, help='Reset workspace contents before execution')
 @click.option('--live', is_flag=True, help='Start container with current directory mounted as workspace')
 @click.option('--env', multiple=True, help='Environment variables to pass to container (format: VAR=value)')
 @debug_option
-def claude(dev_name: str, prompt: str, reset_workspace: bool, live: bool, env: tuple, debug: bool) -> None:
-    """Execute Claude CLI in devcontainer.
-    
+def claude(dev_name: str, prompt: str, auth: bool, api_key: str, reset_workspace: bool, live: bool, env: tuple, debug: bool) -> None:
+    """Execute Claude CLI in devcontainer or set up authentication.
+
     DEV_NAME: Development environment name
     PROMPT: Prompt to send to Claude
-    
+
     Example: devs claude sally "Summarize this codebase"
     Example: devs claude sally "Fix the tests" --reset-workspace
     Example: devs claude sally "Fix the tests" --live  # Run with current directory
     Example: devs claude sally "Start the server" --env QUART_PORT=5001
+    Example: devs claude --auth                        # Interactive authentication
+    Example: devs claude --auth --api-key <YOUR_KEY>   # API key authentication
     """
+    # Handle authentication mode
+    if auth:
+        _handle_claude_auth(api_key=api_key, debug=debug)
+        return
+
+    # Validate required arguments for execution mode
+    if not dev_name or not prompt:
+        raise click.UsageError("DEV_NAME and PROMPT are required unless using --auth")
+
     check_dependencies()
     project = get_project()
-    
+
     # Load environment variables from DEVS.yml and merge with CLI --env flags
     devs_env = DevsConfigLoader.load_env_vars(dev_name, project.info.name)
     cli_env = parse_env_vars(env) if env else {}
     extra_env = merge_env_vars(devs_env, cli_env) if devs_env or cli_env else None
-    
+
     if extra_env:
         console.print(f"🔧 Environment variables: {', '.join(f'{k}={v}' for k, v in extra_env.items())}")
-    
+
     container_manager = ContainerManager(project, config)
     workspace_manager = WorkspaceManager(project, config)
-    
+
     try:
         # Ensure workspace exists (handles live mode and reset internally)
         workspace_dir = workspace_manager.create_workspace(dev_name, reset_contents=reset_workspace, live=live)
         # Ensure container is running
         container_manager.ensure_container_running(
-            dev_name=dev_name, 
-            workspace_dir=workspace_dir, 
-            force_rebuild=False, 
-            debug=debug, 
-            live=live, 
+            dev_name=dev_name,
+            workspace_dir=workspace_dir,
+            force_rebuild=False,
+            debug=debug,
+            live=live,
             extra_env=extra_env
         )
-        
+
         # Execute Claude
         console.print(f"🤖 Executing Claude in {dev_name}...")
         if reset_workspace and not live:
             console.print("🗑️  Workspace contents reset")
         console.print(f"📝 Prompt: {prompt}")
         console.print("")
-        
+
         success, output, error = container_manager.exec_claude(
             dev_name=dev_name,
-            workspace_dir=workspace_dir, 
-            prompt=prompt, 
-            debug=debug, 
-            stream=True, 
-            live=live, 
+            workspace_dir=workspace_dir,
+            prompt=prompt,
+            debug=debug,
+            stream=True,
+            live=live,
             extra_env=extra_env
         )
-        
+
         console.print("")  # Add spacing after streamed output
         if success:
             console.print("✅ Claude execution completed")
@@ -399,9 +412,100 @@ def claude(dev_name: str, prompt: str, reset_workspace: bool, live: bool, env: t
                 console.print("🚫 Error:")
                 console.print(error)
             sys.exit(1)
-        
+
     except (ContainerError, WorkspaceError) as e:
         console.print(f"❌ Error executing Claude in {dev_name}: {e}")
+        sys.exit(1)
+
+
+def _handle_claude_auth(api_key: str, debug: bool) -> None:
+    """Handle Claude authentication setup.
+
+    This configures Claude authentication that will be shared across
+    all devcontainers for this project. The authentication is stored
+    on the host and bind-mounted into containers.
+    """
+    try:
+        # Ensure Claude config directory exists
+        config.ensure_directories()
+
+        console.print("🔐 Setting up Claude authentication...")
+        console.print(f"   Configuration will be saved to: {config.claude_config_dir}")
+
+        if api_key:
+            # Set API key directly using Claude CLI
+            console.print("   Using provided API key...")
+
+            # Set CLAUDE_CONFIG_DIR to our config directory and run auth with API key
+            env = os.environ.copy()
+            env['CLAUDE_CONFIG_DIR'] = str(config.claude_config_dir)
+
+            cmd = ['claude', 'auth', '--key', api_key]
+
+            if debug:
+                console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
+                console.print(f"[dim]CLAUDE_CONFIG_DIR: {config.claude_config_dir}[/dim]")
+
+            result = subprocess.run(
+                cmd,
+                env=env,
+                capture_output=True,
+                text=True
+            )
+
+            if result.returncode != 0:
+                error_msg = result.stderr or result.stdout or "Unknown error"
+                raise Exception(f"Claude authentication failed: {error_msg}")
+
+        else:
+            # Interactive authentication
+            console.print("   Starting interactive authentication...")
+            console.print("   Follow the prompts to authenticate with Claude")
+            console.print("")
+
+            # Set CLAUDE_CONFIG_DIR to our config directory
+            env = os.environ.copy()
+            env['CLAUDE_CONFIG_DIR'] = str(config.claude_config_dir)
+
+            cmd = ['claude', 'auth']
+
+            if debug:
+                console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
+                console.print(f"[dim]CLAUDE_CONFIG_DIR: {config.claude_config_dir}[/dim]")
+
+            # Run interactively
+            result = subprocess.run(
+                cmd,
+                env=env,
+                check=False
+            )
+
+            if result.returncode != 0:
+                raise Exception("Claude authentication was cancelled or failed")
+
+        console.print("")
+        console.print("✅ Claude authentication configured successfully!")
+        console.print(f"   Configuration saved to: {config.claude_config_dir}")
+        console.print("   This authentication will be shared across all devcontainers")
+        console.print("")
+        console.print("💡 You can now use Claude in any devcontainer:")
+        console.print("   devs claude <dev-name> 'Your prompt here'")
+
+    except FileNotFoundError:
+        console.print("❌ Claude CLI not found on host machine")
+        console.print("")
+        console.print("Please install Claude CLI first:")
+        console.print("   npm install -g @anthropic-ai/claude-cli")
+        console.print("")
+        console.print("Note: Claude needs to be installed on the host machine")
+        console.print("      for authentication. It's already available in containers.")
+        sys.exit(1)
+
+    except Exception as e:
+        console.print(f"❌ Failed to configure Claude authentication: {e}")
+        if debug:
+            import traceback
+            console.print(traceback.format_exc())
         sys.exit(1)
 
 
@@ -489,104 +593,6 @@ def runtests(dev_name: str, reset_workspace: bool, live: bool, env: tuple, debug
         
     except (ContainerError, WorkspaceError) as e:
         console.print(f"❌ Error running tests in {dev_name}: {e}")
-        sys.exit(1)
-
-
-@cli.command('claude-auth')
-@click.option('--api-key', help='Claude API key to authenticate with')
-@debug_option
-def claude_auth(api_key: str, debug: bool) -> None:
-    """Set up Claude authentication for devcontainers.
-    
-    This configures Claude authentication that will be shared across
-    all devcontainers for this project. The authentication is stored
-    on the host and bind-mounted into containers.
-    
-    Example: devs claude-auth
-    Example: devs claude-auth --api-key <YOUR_API_KEY>
-    """
-    
-    try:
-        # Ensure Claude config directory exists
-        config.ensure_directories()
-        
-        console.print("🔐 Setting up Claude authentication...")
-        console.print(f"   Configuration will be saved to: {config.claude_config_dir}")
-        
-        if api_key:
-            # Set API key directly using Claude CLI
-            console.print("   Using provided API key...")
-            
-            # Set CLAUDE_CONFIG_DIR to our config directory and run auth with API key
-            env = os.environ.copy()
-            env['CLAUDE_CONFIG_DIR'] = str(config.claude_config_dir)
-            
-            cmd = ['claude', 'auth', '--key', api_key]
-            
-            if debug:
-                console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
-                console.print(f"[dim]CLAUDE_CONFIG_DIR: {config.claude_config_dir}[/dim]")
-            
-            result = subprocess.run(
-                cmd,
-                env=env,
-                capture_output=True,
-                text=True
-            )
-            
-            if result.returncode != 0:
-                error_msg = result.stderr or result.stdout or "Unknown error"
-                raise Exception(f"Claude authentication failed: {error_msg}")
-                
-        else:
-            # Interactive authentication
-            console.print("   Starting interactive authentication...")
-            console.print("   Follow the prompts to authenticate with Claude")
-            console.print("")
-            
-            # Set CLAUDE_CONFIG_DIR to our config directory
-            env = os.environ.copy()
-            env['CLAUDE_CONFIG_DIR'] = str(config.claude_config_dir)
-            
-            cmd = ['claude', 'auth']
-            
-            if debug:
-                console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
-                console.print(f"[dim]CLAUDE_CONFIG_DIR: {config.claude_config_dir}[/dim]")
-            
-            # Run interactively
-            result = subprocess.run(
-                cmd,
-                env=env,
-                check=False
-            )
-            
-            if result.returncode != 0:
-                raise Exception("Claude authentication was cancelled or failed")
-        
-        console.print("")
-        console.print("✅ Claude authentication configured successfully!")
-        console.print(f"   Configuration saved to: {config.claude_config_dir}")
-        console.print("   This authentication will be shared across all devcontainers")
-        console.print("")
-        console.print("💡 You can now use Claude in any devcontainer:")
-        console.print("   devs claude <dev-name> 'Your prompt here'")
-        
-    except FileNotFoundError:
-        console.print("❌ Claude CLI not found on host machine")
-        console.print("")
-        console.print("Please install Claude CLI first:")
-        console.print("   npm install -g @anthropic-ai/claude-cli")
-        console.print("")
-        console.print("Note: Claude needs to be installed on the host machine")
-        console.print("      for authentication. It's already available in containers.")
-        sys.exit(1)
-        
-    except Exception as e:
-        console.print(f"❌ Failed to configure Claude authentication: {e}")
-        if debug:
-            import traceback
-            console.print(traceback.format_exc())
         sys.exit(1)
 
 

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -123,31 +123,32 @@ class TestCLI:
         assert result.exit_code != 0
         assert "Missing argument" in result.output
     
-    def test_claude_auth_command_help(self):
-        """Test claude-auth command help."""
+    def test_claude_command_help(self):
+        """Test claude command help."""
         runner = CliRunner()
-        result = runner.invoke(cli, ['claude-auth', '--help'])
-        
+        result = runner.invoke(cli, ['claude', '--help'])
+
         assert result.exit_code == 0
-        assert "Set up Claude authentication" in result.output
+        assert "Execute Claude CLI in devcontainer or set up authentication" in result.output
+        assert "--auth" in result.output
         assert "--api-key" in result.output
-    
+
     @patch('devs.cli.subprocess.run')
     @patch('devs.cli.config')
     def test_claude_auth_with_api_key(self, mock_config, mock_subprocess):
-        """Test claude-auth command with API key."""
+        """Test claude --auth command with API key."""
         # Setup mocks
         mock_config.claude_config_dir = '/tmp/test-claude-config'
         mock_config.ensure_directories = Mock()
         mock_subprocess.return_value.returncode = 0
-        
+
         runner = CliRunner()
-        result = runner.invoke(cli, ['claude-auth', '--api-key', 'test-key-123'])
-        
+        result = runner.invoke(cli, ['claude', '--auth', '--api-key', 'test-key-123'])
+
         assert result.exit_code == 0
         assert "Setting up Claude authentication" in result.output
         assert "Claude authentication configured successfully" in result.output
-        
+
         # Verify subprocess was called with correct arguments
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args
@@ -155,43 +156,51 @@ class TestCLI:
         assert 'auth' in call_args[0][0]
         assert '--key' in call_args[0][0]
         assert 'test-key-123' in call_args[0][0]
-    
+
     @patch('devs.cli.subprocess.run')
     @patch('devs.cli.config')
     def test_claude_auth_interactive(self, mock_config, mock_subprocess):
-        """Test claude-auth command in interactive mode."""
+        """Test claude --auth command in interactive mode."""
         # Setup mocks
         mock_config.claude_config_dir = '/tmp/test-claude-config'
         mock_config.ensure_directories = Mock()
         mock_subprocess.return_value.returncode = 0
-        
+
         runner = CliRunner()
-        result = runner.invoke(cli, ['claude-auth'])
-        
+        result = runner.invoke(cli, ['claude', '--auth'])
+
         assert result.exit_code == 0
         assert "Setting up Claude authentication" in result.output
         assert "Starting interactive authentication" in result.output
         assert "Claude authentication configured successfully" in result.output
-        
+
         # Verify subprocess was called for interactive auth
         mock_subprocess.assert_called_once()
         call_args = mock_subprocess.call_args
         assert 'claude' in call_args[0][0]
         assert 'auth' in call_args[0][0]
         assert '--key' not in call_args[0][0]
-    
+
     @patch('devs.cli.subprocess.run')
     @patch('devs.cli.config')
     def test_claude_auth_command_not_found(self, mock_config, mock_subprocess):
-        """Test claude-auth when claude CLI is not installed."""
+        """Test claude --auth when claude CLI is not installed."""
         # Setup mocks
         mock_config.claude_config_dir = '/tmp/test-claude-config'
         mock_config.ensure_directories = Mock()
         mock_subprocess.side_effect = FileNotFoundError()
-        
+
         runner = CliRunner()
-        result = runner.invoke(cli, ['claude-auth'])
-        
+        result = runner.invoke(cli, ['claude', '--auth'])
+
         assert result.exit_code == 1
         assert "Claude CLI not found" in result.output
         assert "npm install -g @anthropic-ai/claude-cli" in result.output
+
+    def test_claude_missing_args(self):
+        """Test claude command without required args (not using --auth)."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ['claude'])
+
+        assert result.exit_code != 0
+        assert "DEV_NAME and PROMPT are required unless using --auth" in result.output


### PR DESCRIPTION
## Summary

- Moves the standalone `devs claude-auth` command into the `devs claude` command via `--auth` flag
- Simplifies the CLI interface by consolidating authentication setup
- No backward compatibility needed as per issue request

## Changes

- Add `--auth` and `--api-key` flags to the `claude` command
- Make `DEV_NAME` and `PROMPT` arguments optional when `--auth` is used
- Extract auth logic to `_handle_claude_auth()` helper function for cleaner code
- Remove the standalone `claude-auth` command
- Update tests for new syntax
- Update CLI README documentation

## New Usage

```bash
# Interactive authentication
devs claude --auth

# API key authentication
devs claude --auth --api-key <YOUR_API_KEY>
```

## Test plan

- [x] Run existing tests - all 17 pass
- [x] Test `devs claude --help` shows new options
- [x] Test `devs claude --auth` triggers auth flow
- [x] Test `devs claude --auth --api-key <key>` triggers non-interactive auth
- [x] Test `devs claude` without args shows appropriate error message

Closes #58