### PR TITLE
Add OpenAI Codex CLI support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,19 @@ The `--live` flag mounts the current directory directly into the container witho
 
 **Live Mode**: Add `--live` flag to `start` or `vscode` commands to mount the current directory directly without creating a workspace copy.
 
+### AI Assistant Commands
+
+Both Claude (Anthropic) and Codex (OpenAI) are supported with similar interfaces:
+
+- `devs claude <name> "<prompt>"` - Execute Claude CLI in devcontainer
+- `devs codex <name> "<prompt>"` - Execute OpenAI Codex CLI in devcontainer
+- `devs claude --auth` - Set up Claude authentication (interactive)
+- `devs codex --auth` - Set up Codex authentication (interactive)
+- `devs claude --auth --api-key <KEY>` - Set up Claude with API key
+- `devs codex --auth --api-key <KEY>` - Set up Codex with API key
+
+Both commands support `--reset-workspace`, `--live`, and `--env` options.
+
 ### Example Workflow
 
 ```bash
@@ -239,6 +252,7 @@ flake8 devs tests      # Linting
 - `DEVS_WORKSPACES_DIR`: Custom workspace directory (default: `~/.devs/workspaces`)
 - `DEVS_PROJECT_PREFIX`: Container name prefix (default: `dev`)
 - `DEVS_CLAUDE_CONFIG_DIR`: Claude config directory (default: `~/.devs/claudeconfig`)
+- `DEVS_CODEX_CONFIG_DIR`: Codex config directory (default: `~/.devs/codexconfig`)
 
 #### GitHub Integration
 

--- a/packages/cli/devs/config.py
+++ b/packages/cli/devs/config.py
@@ -15,17 +15,24 @@ class Config(BaseConfig):
     WORKSPACES_DIR = Path.home() / ".devs" / "workspaces"
     BRIDGE_DIR = Path.home() / ".devs" / "bridge"
     CLAUDE_CONFIG_DIR = Path.home() / ".devs" / "claudeconfig"
-    
+    CODEX_CONFIG_DIR = Path.home() / ".devs" / "codexconfig"
+
     def __init__(self) -> None:
         """Initialize configuration with environment variable overrides."""
         super().__init__()
-        
+
         # CLI-specific configuration
         claude_config_env = os.getenv("DEVS_CLAUDE_CONFIG_DIR")
         if claude_config_env:
             self.claude_config_dir = Path(claude_config_env)
         else:
             self.claude_config_dir = self.CLAUDE_CONFIG_DIR
+
+        codex_config_env = os.getenv("DEVS_CODEX_CONFIG_DIR")
+        if codex_config_env:
+            self.codex_config_dir = Path(codex_config_env)
+        else:
+            self.codex_config_dir = self.CODEX_CONFIG_DIR
     
     def get_default_workspaces_dir(self) -> Path:
         """Get default workspaces directory for CLI package."""
@@ -43,6 +50,7 @@ class Config(BaseConfig):
         """Ensure required directories exist."""
         super().ensure_directories()
         self.claude_config_dir.mkdir(parents=True, exist_ok=True)
+        self.codex_config_dir.mkdir(parents=True, exist_ok=True)
 
 
 # Global config instance

--- a/packages/common/devs_common/core/container.py
+++ b/packages/common/devs_common/core/container.py
@@ -725,3 +725,33 @@ class ContainerManager:
             live=live,
             extra_env=extra_env
         )
+
+    def exec_codex(self, dev_name: str, workspace_dir: Path, prompt: str, debug: bool = False, stream: bool = True, live: bool = False, extra_env: Optional[Dict[str, str]] = None) -> tuple[bool, str, str]:
+        """Execute OpenAI Codex CLI in the container.
+
+        Args:
+            dev_name: Development environment name
+            workspace_dir: Workspace directory path
+            prompt: Prompt to send to Codex
+            debug: Show debug output for devcontainer operations
+            stream: Stream output to console in real-time
+            live: Whether the container is in live mode
+            extra_env: Additional environment variables to pass to container
+
+        Returns:
+            Tuple of (success, stdout, stderr)
+
+        Raises:
+            ContainerError: If Codex execution fails
+        """
+        # Simply delegate to exec_command with the Codex command and prompt as stdin
+        return self.exec_command(
+            dev_name=dev_name,
+            workspace_dir=workspace_dir,
+            command="codex --full-auto",
+            stdin_input=prompt,
+            debug=debug,
+            stream=stream,
+            live=live,
+            extra_env=extra_env
+        )

--- a/packages/common/devs_common/templates/Dockerfile
+++ b/packages/common/devs_common/templates/Dockerfile
@@ -87,7 +87,7 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 ENV DEVCONTAINER=true
 
 # Create workspace and config directories and set permissions
-RUN mkdir -p /workspaces /home/node/claudeconfig /home/node/.vscode-server/extensions && \
+RUN mkdir -p /workspaces /home/node/claudeconfig /home/node/codexconfig /home/node/.vscode-server/extensions && \
   echo '[]' > /home/node/.vscode-server/extensions/extensions.json && \
   chown -R node:node /workspaces /home/node /home/node/.vscode-server && \
   chmod 755 /workspaces
@@ -119,14 +119,16 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
   -x
 
-# Install Claude CLI
-RUN npm install -g @anthropic-ai/claude-code
+# Install Claude CLI and OpenAI Codex CLI
+RUN npm install -g @anthropic-ai/claude-code @openai/codex
 
-# Set up environment variables and aliases for Claude
+# Set up environment variables and aliases for Claude and Codex
 USER root
 RUN for shell_rc in /home/node/.zshrc /home/node/.bashrc; do \
   echo "export CLAUDE_CONFIG_DIR=\"/home/node/claudeconfig\"" >> "$shell_rc" && \
+  echo "export CODEX_CONFIG_HOME=\"/home/node/codexconfig\"" >> "$shell_rc" && \
   echo "alias claude=\"/usr/local/share/npm-global/bin/claude --dangerously-skip-permissions\"" >> "$shell_rc" && \
+  echo "alias codex=\"/usr/local/share/npm-global/bin/codex --full-auto\"" >> "$shell_rc" && \
   echo "" >> "$shell_rc" && \
   echo "# Auto-activate Python venv if it exists" >> "$shell_rc" && \
   echo "if [ -f /home/node/.devs-venv/workspace-venv/bin/activate ]; then" >> "$shell_rc" && \

--- a/packages/common/devs_common/templates/devcontainer.json
+++ b/packages/common/devs_common/templates/devcontainer.json
@@ -76,6 +76,7 @@
   "mounts": [
     "source=claude-code-bashhistory,target=/commandhistory,type=volume",
     "source=${localEnv:HOME}/.devs/claudeconfig,target=/home/node/claudeconfig,type=bind",
+    "source=${localEnv:HOME}/.devs/codexconfig,target=/home/node/codexconfig,type=bind",
     "source=${localEnv:DEVS_ENV_MOUNT_PATH},target=/home/node/.devs-env,type=bind",
     "source=${localEnv:DEVS_BRIDGE_MOUNT_PATH},target=/home/node/bridge,type=bind",
     // Remove the extensions mount to get fresh state each time


### PR DESCRIPTION
## Summary

This PR adds support for OpenAI Codex CLI alongside the existing Claude CLI, addressing #60.

- Add `devs codex` command with the same interface as `devs claude`
- Support `--auth` flag for Codex authentication setup (interactive and API key modes)
- Mount `~/.devs/codexconfig` into containers at `/home/node/codexconfig`
- Install `@openai/codex` in devcontainer template alongside Claude
- Configure `CODEX_CONFIG_HOME` environment variable in containers
- Add alias `codex` in containers that runs with `--full-auto` flag

## Usage

```bash
# Set up authentication (interactive)
devs codex --auth

# Set up authentication with API key
devs codex --auth --api-key <YOUR_KEY>

# Execute Codex in a container
devs codex bob "Summarize this codebase"

# With live mode and environment variables
devs codex bob "Fix the tests" --live --env DEBUG=true
```

## Test plan

- [x] Added tests for `devs codex --help`
- [x] Added tests for `devs codex --auth` (interactive mode)
- [x] Added tests for `devs codex --auth --api-key <KEY>`
- [x] Added tests for `devs codex` without required args (error handling)
- [x] Added test for Codex CLI not found scenario
- [x] All 22 CLI tests passing