### PR TITLE
Add rocket reaction on worker completion

### DIFF
--- a/packages/webhook/devs_webhook/core/container_pool.py
+++ b/packages/webhook/devs_webhook/core/container_pool.py
@@ -1082,30 +1082,11 @@ Please check the webhook handler logs for more details, or try mentioning me aga
             github_client = GitHubClient(self.config)
 
             repo_name = queued_task.event.repository.full_name
-            reaction_added = False
 
-            # Add reaction based on event type
-            if isinstance(queued_task.event, CommentEvent):
-                # React to the comment itself
-                reaction_added = await github_client.add_reaction_to_comment(
-                    repo=repo_name,
-                    comment_id=queued_task.event.comment.id,
-                    reaction="rocket"
-                )
-            elif isinstance(queued_task.event, IssueEvent):
-                # React to the issue
-                reaction_added = await github_client.add_reaction_to_issue(
-                    repo=repo_name,
-                    issue_number=queued_task.event.issue.number,
-                    reaction="rocket"
-                )
-            elif isinstance(queued_task.event, PullRequestEvent):
-                # React to the PR
-                reaction_added = await github_client.add_reaction_to_pr(
-                    repo=repo_name,
-                    pr_number=queued_task.event.pull_request.number,
-                    reaction="rocket"
-                )
+            reaction_added = await github_client.add_reaction_to_event(
+                event=queued_task.event,
+                reaction="rocket"
+            )
 
             if reaction_added:
                 logger.info("Successfully added completion reaction",

--- a/packages/webhook/devs_webhook/core/task_processor.py
+++ b/packages/webhook/devs_webhook/core/task_processor.py
@@ -10,7 +10,6 @@ import structlog
 from ..config import get_config
 from ..github.parser import WebhookParser
 from ..github.client import GitHubClient
-from ..github.models import IssueEvent, PullRequestEvent, CommentEvent
 from .container_pool import ContainerPool
 from .deduplication import is_duplicate_content, get_cache_stats
 
@@ -50,39 +49,10 @@ class TaskProcessor:
             repo_name: Repository in format "owner/repo"
         """
         try:
-            reaction_added = False
-
-            # Determine what to react to based on event type
-            if isinstance(event, CommentEvent):
-                # React to the comment itself
-                reaction_added = await self.github_client.add_reaction_to_comment(
-                    repo=repo_name,
-                    comment_id=event.comment.id,
-                    reaction="eyes"
-                )
-                logger.info("Attempting to add reaction to comment",
-                           comment_id=event.comment.id,
-                           repo=repo_name)
-            elif isinstance(event, IssueEvent):
-                # React to the issue
-                reaction_added = await self.github_client.add_reaction_to_issue(
-                    repo=repo_name,
-                    issue_number=event.issue.number,
-                    reaction="eyes"
-                )
-                logger.info("Attempting to add reaction to issue",
-                           issue_number=event.issue.number,
-                           repo=repo_name)
-            elif isinstance(event, PullRequestEvent):
-                # React to the PR (PRs are issues in GitHub API)
-                reaction_added = await self.github_client.add_reaction_to_pr(
-                    repo=repo_name,
-                    pr_number=event.pull_request.number,
-                    reaction="eyes"
-                )
-                logger.info("Attempting to add reaction to PR",
-                           pr_number=event.pull_request.number,
-                           repo=repo_name)
+            reaction_added = await self.github_client.add_reaction_to_event(
+                event=event,
+                reaction="eyes"
+            )
 
             if reaction_added:
                 logger.info("Successfully added eyes reaction",


### PR DESCRIPTION
## Summary
- Adds a 🚀 rocket reaction when a webhook task finishes processing
- Complements the existing 👀 eyes reaction added when a task is queued
- Provides visual feedback that the worker completed, even if Claude doesn't write output to the issue

## Test plan
- [x] All 72 existing tests pass
- [ ] Manual test: trigger a webhook and verify rocket reaction appears on completion

Closes #73