### PR TITLE
Skip CI for draft PRs and add draft_prs config option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,7 +346,10 @@ default_branch: develop  # Override default branch (default: main)
 prompt_extra: |          # Additional Claude instructions
   This project uses specific coding standards...
 single_queue: true       # Process all events sequentially in same container (default: false)
+draft_prs: true          # Instruct Claude to create PRs as drafts until told otherwise (default: false)
 ```
+
+**Note on CI and Draft PRs**: When `ci_enabled: true`, CI/test runs are automatically skipped for draft PRs. This prevents unnecessary test runs while work is still in progress. Tests will run automatically when the PR is marked ready for review.
 
 ### DevContainer Support
 

--- a/packages/common/devs_common/devs_config.py
+++ b/packages/common/devs_common/devs_config.py
@@ -23,6 +23,7 @@ class DevsOptions(BaseModel):
     ci_enabled: bool = False  # Enable CI mode for this repository
     ci_test_command: str = "./runtests.sh"  # Command to run for CI tests
     ci_branches: List[str] = ["main", "master"]  # Branches to run CI on for push events
+    draft_prs: bool = False  # When enabled, instruct Claude to create/maintain PRs as drafts
     env_vars: Dict[str, Dict[str, str]] = Field(default_factory=dict)  # Environment variables
     
     def get_env_vars(self, container_name: Optional[str] = None) -> Dict[str, str]:

--- a/packages/webhook/devs_webhook/core/claude_dispatcher.py
+++ b/packages/webhook/devs_webhook/core/claude_dispatcher.py
@@ -236,15 +236,22 @@ Always remember to PUSH your work to origin!
                 pr_closing_instruction = ""
                 if not is_pr:
                     pr_closing_instruction = " (mention that it closes an issue number if it does)"
-                
+
+                # Add draft PR instruction if enabled in DEVS.yml
+                draft_pr_instruction = ""
+                if devs_options and devs_options.draft_prs:
+                    draft_pr_instruction = """
+IMPORTANT: Create pull requests as DRAFTS using `gh pr create --draft`. Keep PRs in draft status until the user explicitly instructs you to mark them ready for review.
+"""
+
                 # Build unified prompt with variable parts
-                prompt = f"""You are an AI developer helping build a software project in a GitHub repository. 
+                prompt = f"""You are an AI developer helping build a software project in a GitHub repository.
 You have been mentioned in a {event_type_full} and need to take action.
 
-You should ensure you're on the latest commits in the repo's default branch. 
-Generally work on feature branches for changes. 
+You should ensure you're on the latest commits in the repo's default branch.
+Generally work on feature branches for changes.
 Submit any changes as a pull request when done{pr_closing_instruction}.
-
+{draft_pr_instruction}
 IMPORTANT: Do not close the issue unless the user explicitly instructs you to do so. Even if you implement a solution, leave the issue open for the user to review and close when they're satisfied.
 
 If you need to ask for clarification, or if only asked for your thoughts, please respond with a comment on the {event_type}.

--- a/packages/webhook/devs_webhook/github/models.py
+++ b/packages/webhook/devs_webhook/github/models.py
@@ -61,6 +61,7 @@ class GitHubPullRequest(BaseModel):
     title: str
     body: Optional[str] = None
     state: str
+    draft: bool = False
     user: GitHubUser
     assignee: Optional[GitHubUser] = None
     html_url: str

--- a/packages/webhook/devs_webhook/github/parser.py
+++ b/packages/webhook/devs_webhook/github/parser.py
@@ -290,15 +290,22 @@ class WebhookParser:
         
         # Handle pull request events for CI
         if isinstance(event, PullRequestEvent):
+            # Skip draft PRs - they shouldn't trigger CI runs
+            if event.pull_request.draft:
+                logger.info("Skipping CI for draft PR",
+                           pr_number=event.pull_request.number,
+                           repo=event.repository.full_name)
+                return False
+
             # Process PR opened, synchronize (new commits), reopened
             ci_pr_actions = ["opened", "synchronize", "reopened"]
             should_process = event.action in ci_pr_actions
-            
+
             logger.info("PR event CI check",
                        action=event.action,
                        ci_pr_actions=ci_pr_actions,
                        should_process=should_process)
-            
+
             return should_process
         
         # Handle push events for CI

--- a/packages/webhook/tests/test_webhook_parser.py
+++ b/packages/webhook/tests/test_webhook_parser.py
@@ -3,7 +3,8 @@
 import json
 import pytest
 from devs_webhook.github.parser import WebhookParser
-from devs_webhook.github.models import IssueEvent, CommentEvent
+from devs_webhook.github.models import IssueEvent, CommentEvent, PullRequestEvent
+from devs_common.devs_config import DevsOptions
 
 
 class TestWebhookParser:
@@ -172,7 +173,123 @@ class TestWebhookParser:
         payload = {"action": "test"}
         headers = {"x-github-event": "unsupported"}
         payload_bytes = json.dumps(payload).encode()
-        
+
         event = WebhookParser.parse_webhook(headers, payload_bytes)
         assert event is None
-    
+
+
+class TestCIProcessing:
+    """Test CI processing functionality."""
+
+    def _create_pr_payload(self, draft: bool = False, action: str = "opened"):
+        """Helper to create a PR payload."""
+        return {
+            "action": action,
+            "pull_request": {
+                "id": 1,
+                "number": 42,
+                "title": "Test PR",
+                "body": "Test PR description",
+                "state": "open",
+                "draft": draft,
+                "user": {
+                    "login": "developer",
+                    "id": 123,
+                    "avatar_url": "https://github.com/avatar.jpg",
+                    "html_url": "https://github.com/developer"
+                },
+                "assignee": None,
+                "html_url": "https://github.com/test/repo/pull/42",
+                "head": {"ref": "feature-branch", "sha": "abc123"},
+                "base": {"ref": "main", "sha": "def456"},
+                "created_at": "2023-01-01T00:00:00Z",
+                "updated_at": "2023-01-01T00:00:00Z"
+            },
+            "repository": {
+                "id": 789,
+                "name": "repo",
+                "full_name": "test/repo",
+                "owner": {
+                    "login": "test",
+                    "id": 111,
+                    "avatar_url": "https://github.com/avatar.jpg",
+                    "html_url": "https://github.com/test"
+                },
+                "html_url": "https://github.com/test/repo",
+                "clone_url": "https://github.com/test/repo.git",
+                "ssh_url": "git@github.com:test/repo.git",
+                "default_branch": "main"
+            },
+            "sender": {
+                "login": "developer",
+                "id": 123,
+                "avatar_url": "https://github.com/avatar.jpg",
+                "html_url": "https://github.com/developer"
+            }
+        }
+
+    def test_ci_skipped_for_draft_pr(self):
+        """Test that CI is skipped for draft PRs."""
+        payload = self._create_pr_payload(draft=True, action="opened")
+        headers = {"x-github-event": "pull_request"}
+        payload_bytes = json.dumps(payload).encode()
+
+        event = WebhookParser.parse_webhook(headers, payload_bytes)
+        devs_options = DevsOptions(ci_enabled=True)
+
+        should_process = WebhookParser.should_process_event_for_ci(event, devs_options)
+
+        assert should_process is False
+
+    def test_ci_runs_for_non_draft_pr(self):
+        """Test that CI runs for non-draft PRs."""
+        payload = self._create_pr_payload(draft=False, action="opened")
+        headers = {"x-github-event": "pull_request"}
+        payload_bytes = json.dumps(payload).encode()
+
+        event = WebhookParser.parse_webhook(headers, payload_bytes)
+        devs_options = DevsOptions(ci_enabled=True)
+
+        should_process = WebhookParser.should_process_event_for_ci(event, devs_options)
+
+        assert should_process is True
+
+    def test_ci_skipped_for_draft_pr_synchronize(self):
+        """Test that CI is skipped for draft PRs on synchronize action."""
+        payload = self._create_pr_payload(draft=True, action="synchronize")
+        headers = {"x-github-event": "pull_request"}
+        payload_bytes = json.dumps(payload).encode()
+
+        event = WebhookParser.parse_webhook(headers, payload_bytes)
+        devs_options = DevsOptions(ci_enabled=True)
+
+        should_process = WebhookParser.should_process_event_for_ci(event, devs_options)
+
+        assert should_process is False
+
+    def test_ci_runs_for_non_draft_pr_synchronize(self):
+        """Test that CI runs for non-draft PRs on synchronize action."""
+        payload = self._create_pr_payload(draft=False, action="synchronize")
+        headers = {"x-github-event": "pull_request"}
+        payload_bytes = json.dumps(payload).encode()
+
+        event = WebhookParser.parse_webhook(headers, payload_bytes)
+        devs_options = DevsOptions(ci_enabled=True)
+
+        should_process = WebhookParser.should_process_event_for_ci(event, devs_options)
+
+        assert should_process is True
+
+    def test_ci_not_processed_when_disabled(self):
+        """Test that CI is not processed when ci_enabled is False."""
+        payload = self._create_pr_payload(draft=False, action="opened")
+        headers = {"x-github-event": "pull_request"}
+        payload_bytes = json.dumps(payload).encode()
+
+        event = WebhookParser.parse_webhook(headers, payload_bytes)
+        devs_options = DevsOptions(ci_enabled=False)
+
+        should_process = WebhookParser.should_process_event_for_ci(event, devs_options)
+
+        assert should_process is False
+


### PR DESCRIPTION
- Skip CI/test runs (Checks API / runtests.sh) for draft PRs
- Add draft field to GitHubPullRequest model to track PR draft status
- Add draft_prs option to DevsOptions schema (DEVS.yml)
- When draft_prs is enabled, prompt instructs Claude to create PRs as drafts
- Add tests for draft PR CI skipping behavior
- Update CLAUDE.md documentation

Closes #85