### PR TITLE
Fix --version to show actual package versions

### DIFF
--- a/packages/cli/devs/__init__.py
+++ b/packages/cli/devs/__init__.py
@@ -3,7 +3,12 @@
 A command-line tool that simplifies managing multiple named devcontainers for any project.
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("devs-cli")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
 __author__ = "Dan Lester"
 __email__ = "dan@ideonate.com"
 

--- a/packages/cli/devs/cli.py
+++ b/packages/cli/devs/cli.py
@@ -4,6 +4,7 @@ import os
 import sys
 import subprocess
 from functools import wraps
+from importlib.metadata import version, PackageNotFoundError
 
 import click
 from rich.console import Console
@@ -114,13 +115,27 @@ def get_project() -> Project:
         sys.exit(1)
 
 
+def _get_version(ctx: click.Context, param: click.Parameter, value: bool) -> None:
+    """Print version info for devs-cli and installed dependencies."""
+    if not value or ctx.resilient_parsing:
+        return
+    parts = []
+    for pkg, label in [("devs-cli", "devs-cli"), ("devs-common", "devs-common"), ("devs-webhook", "devs-webhook")]:
+        try:
+            parts.append(f"{label} {version(pkg)}")
+        except PackageNotFoundError:
+            pass
+    click.echo("\n".join(parts) if parts else "devs-cli (unknown version)")
+    ctx.exit()
+
+
 @click.group()
-@click.version_option(version="0.1.0", prog_name="devs")
+@click.option('--version', is_flag=True, callback=_get_version, expose_value=False, is_eager=True, help='Show version and exit.')
 @click.option('--debug', is_flag=True, help='Show debug tracebacks on error')
 @click.pass_context
 def cli(ctx, debug: bool) -> None:
     """DevContainer Management Tool
-    
+
     Manage multiple named devcontainers for any project.
     """
     ctx.ensure_object(dict)


### PR DESCRIPTION
## Summary
- Fixes `devs --version` showing hardcoded `0.1.0` instead of the real version
- Uses `importlib.metadata` to dynamically read version from installed package metadata
- Shows versions for `devs-cli`, `devs-common`, and `devs-webhook` (when installed)

Example output:
```
$ devs --version
devs-cli 2.0.2
devs-common 2.0.2
devs-webhook 2.0.2
```

Closes #87

## Test plan
- [x] `devs --version` shows correct version from pyproject.toml
- [x] `python -c "import devs; print(devs.__version__)"` returns correct version
- [x] Dependency versions (devs-common, devs-webhook) shown when installed