### PR TITLE
Implement devs list --all-projects

### DIFF
--- a/packages/cli/devs/cli.py
+++ b/packages/cli/devs/cli.py
@@ -900,25 +900,56 @@ def list(all_projects: bool) -> None:
     
     if all_projects:
         console.print("📋 All devcontainers:")
-        # This would require a more complex implementation
-        console.print("   --all-projects not implemented yet")
+        console.print("")
+
+        try:
+            containers = ContainerManager.list_all_containers()
+
+            if not containers:
+                console.print("   No active devcontainers found")
+                return
+
+            table = Table()
+            table.add_column("Project", style="magenta")
+            table.add_column("Name", style="cyan")
+            table.add_column("Mode", style="yellow")
+            table.add_column("Status", style="green")
+            table.add_column("Container", style="dim")
+            table.add_column("Created", style="dim")
+
+            for container in containers:
+                created_str = container.created.strftime("%Y-%m-%d %H:%M") if container.created else "unknown"
+                mode = "live" if container.labels.get('devs.live') == 'true' else "copy"
+                table.add_row(
+                    container.project_name,
+                    container.dev_name,
+                    mode,
+                    container.status,
+                    container.name,
+                    created_str
+                )
+
+            console.print(table)
+
+        except ContainerError as e:
+            console.print(f"❌ Error listing containers: {e}")
         return
-    
+
     project = get_project()
     container_manager = ContainerManager(project, config)
-    
+
     console.print(f"📋 Active devcontainers for project: {project.info.name}")
     console.print("")
-    
+
     try:
         containers = container_manager.list_containers()
-        
+
         if not containers:
             console.print("   No active devcontainers found")
             console.print("")
             console.print("💡 Start some with: devs start <dev-name>")
             return
-        
+
         # Create a table
         table = Table()
         table.add_column("Name", style="cyan")
@@ -926,7 +957,7 @@ def list(all_projects: bool) -> None:
         table.add_column("Status", style="green")
         table.add_column("Container", style="dim")
         table.add_column("Created", style="dim")
-        
+
         for container in containers:
             created_str = container.created.strftime("%Y-%m-%d %H:%M") if container.created else "unknown"
             mode = "live" if container.labels.get('devs.live') == 'true' else "copy"
@@ -937,13 +968,13 @@ def list(all_projects: bool) -> None:
                 container.name,
                 created_str
             )
-        
+
         console.print(table)
         console.print("")
         console.print("💡 Open with: devs vscode <dev-name>")
         console.print("💡 Shell into: devs shell <dev-name>")
         console.print("💡 Stop with: devs stop <dev-name>")
-        
+
     except ContainerError as e:
         console.print(f"❌ Error listing containers: {e}")
 

--- a/packages/cli/tests/test_cli_misc.py
+++ b/packages/cli/tests/test_cli_misc.py
@@ -69,21 +69,50 @@ class TestListCommand:
             assert result.exit_code == 0
             assert "No active devcontainers found" in result.output
     
-    @patch('devs.cli.Project')
-    def test_list_all_containers(self, mock_project_class, cli_runner, temp_project):
-        """Test listing all devs containers - --all-projects not yet implemented."""
-        # Setup mocks
-        mock_project = Mock()
-        mock_project.path = temp_project
-        mock_project.info.name = "test-org-test-repo"
-        mock_project_class.return_value = mock_project
+    @patch('devs.cli.ContainerManager')
+    def test_list_all_projects(self, mock_container_manager_class, cli_runner, temp_project):
+        """Test listing containers across all projects."""
+        mock_container_manager_class.list_all_containers.return_value = [
+            MockContainer("/dev-org-a-repo-a-alice", "running", {
+                "devs.project": "org-a-repo-a",
+                "devs.name": "alice",
+                "devs.managed": "true"
+            }),
+            MockContainer("/dev-org-a-repo-a-bob", "exited", {
+                "devs.project": "org-a-repo-a",
+                "devs.name": "bob",
+                "devs.managed": "true"
+            }),
+            MockContainer("/dev-org-b-repo-b-charlie", "running", {
+                "devs.project": "org-b-repo-b",
+                "devs.name": "charlie",
+                "devs.managed": "true"
+            }),
+        ]
 
-        # Run command with --all-projects (not --all)
         result = cli_runner.invoke(cli, ['list', '--all-projects'])
 
-        # --all-projects is not implemented yet, verify the output message
         assert result.exit_code == 0
-        assert "--all-projects not implemented yet" in result.output
+        assert "All devcontainers" in result.output
+        assert "org-a-repo-a" in result.output
+        assert "org-b-repo-b" in result.output
+        assert "alice" in result.output
+        assert "bob" in result.output
+        assert "charlie" in result.output
+        assert "running" in result.output
+        assert "exited" in result.output
+        # Should include Project column
+        mock_container_manager_class.list_all_containers.assert_called_once()
+
+    @patch('devs.cli.ContainerManager')
+    def test_list_all_projects_no_containers(self, mock_container_manager_class, cli_runner, temp_project):
+        """Test --all-projects when no containers exist."""
+        mock_container_manager_class.list_all_containers.return_value = []
+
+        result = cli_runner.invoke(cli, ['list', '--all-projects'])
+
+        assert result.exit_code == 0
+        assert "No active devcontainers found" in result.output
 
 
 class TestStatusCommand:

--- a/packages/cli/tests/test_container_manager.py
+++ b/packages/cli/tests/test_container_manager.py
@@ -125,6 +125,77 @@ class TestContainerManager:
                 assert all(isinstance(c, ContainerInfo) for c in containers)
                 assert {c.dev_name for c in containers} == {"alice", "bob"}
 
+    def test_list_all_containers(self):
+        """Test listing all devs-managed containers across all projects."""
+        with patch('devs_common.core.container.DockerClient') as mock_docker_client_class:
+            mock_docker_instance = MagicMock()
+            mock_docker_client_class.return_value = mock_docker_instance
+
+            mock_docker_instance.find_containers_by_labels.return_value = [
+                {
+                    'name': 'dev-org-a-repo-a-alice',
+                    'id': 'abc123',
+                    'status': 'running',
+                    'labels': {
+                        'devs.managed': 'true',
+                        'devs.project': 'org-a-repo-a',
+                        'devs.dev': 'alice'
+                    },
+                    'created': '2025-01-01T00:00:00.000000Z'
+                },
+                {
+                    'name': 'dev-org-b-repo-b-bob',
+                    'id': 'def456',
+                    'status': 'exited',
+                    'labels': {
+                        'devs.managed': 'true',
+                        'devs.project': 'org-b-repo-b',
+                        'devs.dev': 'bob'
+                    },
+                    'created': '2025-01-02T00:00:00.000000Z'
+                },
+                {
+                    'name': 'dev-org-a-repo-a-charlie',
+                    'id': 'ghi789',
+                    'status': 'running',
+                    'labels': {
+                        'devs.managed': 'true',
+                        'devs.project': 'org-a-repo-a',
+                        'devs.dev': 'charlie'
+                    },
+                    'created': '2025-01-03T00:00:00.000000Z'
+                },
+            ]
+
+            containers = ContainerManager.list_all_containers()
+
+            # Verify it searched with devs.managed label
+            mock_docker_instance.find_containers_by_labels.assert_called_once_with(
+                {"devs.managed": "true"}
+            )
+
+            assert len(containers) == 3
+            assert all(isinstance(c, ContainerInfo) for c in containers)
+
+            # Verify sorted by project name then dev name
+            assert containers[0].project_name == "org-a-repo-a"
+            assert containers[0].dev_name == "alice"
+            assert containers[1].project_name == "org-a-repo-a"
+            assert containers[1].dev_name == "charlie"
+            assert containers[2].project_name == "org-b-repo-b"
+            assert containers[2].dev_name == "bob"
+
+    def test_list_all_containers_empty(self):
+        """Test listing all containers when none exist."""
+        with patch('devs_common.core.container.DockerClient') as mock_docker_client_class:
+            mock_docker_instance = MagicMock()
+            mock_docker_client_class.return_value = mock_docker_instance
+            mock_docker_instance.find_containers_by_labels.return_value = []
+
+            containers = ContainerManager.list_all_containers()
+
+            assert len(containers) == 0
+
     def test_stop_container_success(self, mock_project):
         """Test successful container stop."""
         with patch('devs_common.utils.docker_client.docker') as mock_docker:

--- a/packages/common/devs_common/core/container.py
+++ b/packages/common/devs_common/core/container.py
@@ -467,7 +467,41 @@ class ContainerManager:
             
         except DockerError as e:
             raise ContainerError(f"Failed to list containers: {e}")
-    
+
+    @staticmethod
+    def list_all_containers() -> List[ContainerInfo]:
+        """List all devs-managed containers across all projects.
+
+        Returns:
+            List of ContainerInfo objects sorted by project name then dev name
+        """
+        try:
+            docker_client = DockerClient()
+            containers = docker_client.find_containers_by_labels({"devs.managed": "true"})
+
+            result = []
+            for container_data in containers:
+                dev_name = container_data['labels'].get('devs.dev', 'unknown')
+                project_name = container_data['labels'].get('devs.project', 'unknown')
+
+                container_info = ContainerInfo(
+                    name=container_data['name'],
+                    dev_name=dev_name,
+                    project_name=project_name,
+                    status=container_data['status'],
+                    container_id=container_data['id'],
+                    created=_parse_docker_timestamp(container_data['created']),
+                    labels=container_data['labels']
+                )
+
+                result.append(container_info)
+
+            result.sort(key=lambda c: (c.project_name, c.dev_name))
+            return result
+
+        except DockerError as e:
+            raise ContainerError(f"Failed to list containers: {e}")
+
     def find_aborted_containers(self, all_projects: bool = False) -> List[ContainerInfo]:
         """Find aborted devs containers that failed during setup.
         


### PR DESCRIPTION
## Summary
- Implements `devs list --all-projects` to list all devs-managed containers across all projects (not just the current working directory's project)
- Adds a `ContainerManager.list_all_containers()` static method that queries Docker for all containers with the `devs.managed=true` label
- Displays results in a table with a Project column, sorted by project name then dev name

## Changes
- `packages/common/devs_common/core/container.py`: Added `list_all_containers()` static method to `ContainerManager`
- `packages/cli/devs/cli.py`: Replaced stub with full implementation of `--all-projects` flag
- `packages/cli/tests/test_cli_misc.py`: Updated tests for the new functionality
- `packages/cli/tests/test_container_manager.py`: Added unit tests for `list_all_containers()`

## Test plan
- [x] All existing tests pass (150 passed, 1 pre-existing version test failure)
- [x] New CLI integration tests for `--all-projects` with containers and empty state
- [x] New unit tests for `list_all_containers()` verifying label filtering and sort order

Closes #90