### PR TITLE
Remove dead MAX_CONCURRENT_TASKS config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,7 +417,6 @@ devs start eamonn --env DEBUG=false --env NEW_VAR=test
 - `CONTAINER_TIMEOUT_MINUTES`: Idle timeout for containers in minutes (default: 60). Only applies when `STOP_CONTAINER_AFTER_TASK` is false.
 - `CONTAINER_MAX_AGE_HOURS`: Maximum container age in hours - containers older than this are cleaned up when idle (default: 10). Only applies when `STOP_CONTAINER_AFTER_TASK` is false.
 - `CLEANUP_CHECK_INTERVAL_SECONDS`: How often to check for idle/old containers (default: 60). Only applies when `STOP_CONTAINER_AFTER_TASK` is false.
-- `MAX_CONCURRENT_TASKS`: Maximum parallel tasks (default: 3)
 
 **Access Control**:
 - `ALLOWED_ORGS`: Comma-separated GitHub organizations

--- a/packages/webhook/.env.example
+++ b/packages/webhook/.env.example
@@ -16,7 +16,6 @@ ADMIN_PASSWORD=your-secure-password-here
 # Container Pool Settings
 # CONTAINER_POOL=eamonn,harry,darren
 # CONTAINER_TIMEOUT_MINUTES=30
-# MAX_CONCURRENT_TASKS=3
 
 # Directory Settings
 # REPO_CACHE_DIR=/custom/path/to/repos

--- a/packages/webhook/README.md
+++ b/packages/webhook/README.md
@@ -50,7 +50,6 @@ export AUTHORIZED_TRIGGER_USERS="danlester,admin"  # Users who can trigger proce
 # Optional settings (with defaults)
 export CONTAINER_POOL="eamonn,harry,darren"
 export CONTAINER_TIMEOUT_MINUTES="30"
-export MAX_CONCURRENT_TASKS="3"
 export WEBHOOK_HOST="0.0.0.0"
 export WEBHOOK_PORT="8000"
 ```
@@ -389,7 +388,6 @@ The webhook handler automatically detects and uses these settings when processin
 | `AUTHORIZED_TRIGGER_USERS`  | (empty - allows all)         | Comma-separated list of users who can trigger events |
 | `CONTAINER_POOL`            | `eamonn,harry,darren`        | Container names                          |
 | `CONTAINER_TIMEOUT_MINUTES` | `30`                         | Container timeout                        |
-| `MAX_CONCURRENT_TASKS`      | `3`                          | Max parallel tasks                       |
 | `REPO_CACHE_DIR`            | `~/.devs-webhook/repos`      | Repository cache                         |
 | `WORKSPACE_DIR`             | `~/.devs-webhook/workspaces` | Container workspaces                     |
 | `WEBHOOK_HOST`              | `0.0.0.0`                    | Server host                              |

--- a/packages/webhook/devs_webhook/config.py
+++ b/packages/webhook/devs_webhook/config.py
@@ -90,8 +90,6 @@ class WebhookConfig(BaseSettings, BaseConfig):
                     "This ensures only one running container per dev name at any time, "
                     "reducing RAM usage when multiple repos are in play."
     )
-    max_concurrent_tasks: int = Field(default=3, description="Maximum concurrent tasks")
-    
     # Repository settings
     repo_cache_dir: Path = Field(
         default_factory=lambda: Path.home() / ".devs" / "repocache",

--- a/packages/webhook/docker-compose.yml
+++ b/packages/webhook/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       # Optional settings with defaults
       - CONTAINER_POOL=${CONTAINER_POOL:-eamonn,harry,darren}
       - CONTAINER_TIMEOUT_MINUTES=${CONTAINER_TIMEOUT_MINUTES:-30}
-      - MAX_CONCURRENT_TASKS=${MAX_CONCURRENT_TASKS:-3}
       - WEBHOOK_HOST=0.0.0.0
       - WEBHOOK_PORT=8000
       - LOG_LEVEL=${LOG_LEVEL:-INFO}


### PR DESCRIPTION
## Summary

- Removes `max_concurrent_tasks` field from `WebhookConfig` in `packages/webhook/devs_webhook/config.py`
- Removes all references from `.env.example`, `docker-compose.yml`, `README.md`, and `CLAUDE.md`

The config was declared but never read anywhere in the code, making it dead config with no effect.

Closes #98